### PR TITLE
Fix menu not working on chrome mobile

### DIFF
--- a/js/scroll.js
+++ b/js/scroll.js
@@ -58,7 +58,8 @@ loadDefault = function() {
     return;
 
   $('.js-menu').on('click', function(e){
-    e.preventDefault();
+    // See http://stackoverflow.com/a/21053259
+    e.stopImmediatePropagation();
     $('div[data-shift]').toggleClass('shift');
     $('div[data-shift-nav]').toggleClass('shift-nav');
   });


### PR DESCRIPTION
- Avatar menu not working on chrome android when address bar hidden
  caused by double event binding call on the .on method.
- See http://stackoverflow.com/a/21053259
